### PR TITLE
Avoid usage of unittest.makeSuite

### DIFF
--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -142,7 +142,7 @@ class DispatcherTests(unittest.TestCase):
         
 
 def getSuite():
-    return unittest.makeSuite(DispatcherTests,'test')
+    return unittest.defaultTestLoader.loadTestsFromTestCase(DispatcherTests,'test')
         
 if __name__ == "__main__":
     unittest.main ()

--- a/tests/test_robustapply.py
+++ b/tests/test_robustapply.py
@@ -32,7 +32,7 @@ class TestCases(unittest.TestCase):
 
 
 def getSuite():
-    return unittest.makeSuite(TestCases, 'test')
+    return unittest.defaultTestLoader.loadTestsFromTestCase(TestCases, 'test')
 
 
 if __name__ == "__main__":

--- a/tests/test_saferef.py
+++ b/tests/test_saferef.py
@@ -70,7 +70,7 @@ class Tester (unittest.TestCase):
         self.closureCount +=1
 
 def getSuite():
-    return unittest.makeSuite(Tester,'test')
+    return unittest.defaultTestLoader.loadTestsFromTestCase(Tester,'test')
 
 if __name__ == "__main__":
     unittest.main ()


### PR DESCRIPTION
Python 3.13 removes unittest.makeSuite.

https://docs.python.org/3.13/whatsnew/3.13.html#unittest